### PR TITLE
add bf size charts

### DIFF
--- a/data/shopify_apps.js
+++ b/data/shopify_apps.js
@@ -2294,5 +2294,13 @@ var SHOPIFY_APPS = [
         app_store_url: "https://apps.shopify.com/getreviews",
         website_url: "https://www.dsreviews.net",
         script_pattern: "api.dsreviews.net",
+    },
+    {
+        name: "BF Size Charts & Size Guides",
+        short_description: "Add size charts to your product pages",
+        app_store_url: "https://apps.shopify.com/size-charts-by-relentless",
+        website_url: "https://www.relentlessapps.com",
+        script_pattern: "size-charts-relentless.js",
+        category: "Store Design"
     }
 ];


### PR DESCRIPTION
# Why?
I just added a new app

# What?
I added BF Size Charts and Size Guides by Relentless Apps


# Demo / Screenshots
Using recordit.co and/or monosnap to give screenshots and gif demos of your code. You can embed them in here like this: `![Brief description of image](https://www.fera.ai/wp-content/uploads/2017/12/cdyUNSv9bq.gif)`
![Brief description of image](https://www.fera.ai/wp-content/uploads/2017/12/cdyUNSv9bq.gif)


# How was it tested?
What tests did you run? What scenarios did you test. What tests do you still need to run?

# How can you test it.
How can the reviewer test this PR? Are there any special steps required? For example:
* `bundle install` (if you added bower assets)
* `bower install` (if you added gems)
* Restart your web server (if you added runtime things or gems)
* Go to `/some_page` in your browser and do X, Y and Z (if there is a visual components)
* Open up your `rails console` and type `some code` (if there are code components to test)
