### PR TITLE
Add PickyStory app

### DIFF
--- a/data/shopify_apps.js
+++ b/data/shopify_apps.js
@@ -2294,5 +2294,14 @@ var SHOPIFY_APPS = [
         app_store_url: "https://apps.shopify.com/getreviews",
         website_url: "https://www.dsreviews.net",
         script_pattern: "api.dsreviews.net",
+    },
+    {
+        name: "PickyStory",
+        short_description: "Automate Upsell & Cross-Sell of Bundles, Kits, and Looks",
+        long_description: "Generate more revenue from every store visit. Sell Shopify product Bundles, Kits, and Looks with one app. It’s easy and done in a few clicks.",
+        app_store_url: "https://apps.shopify.com/product-kits-bundles-pickystory",
+        website_url: "https://pickystory.com/",
+        category: "Sales",
+        script_pattern: /cdn\.pickystory\.com\/widget\/dist\/latest\/pickystory-widget\.min\.js/,
     }
 ];


### PR DESCRIPTION
Add PickyStory app detection.

For details about the app: https://apps.shopify.com/product-kits-bundles-pickystory.

The detection uses a script pattern identifying our main script `cdn.pickystory.com/widget/dist/latest/pickystory-widget.min.js`.

Tested in our demo store https://try.pickystory.com/products/upsell-on-product-pages-fashion:
![image](https://user-images.githubusercontent.com/40914561/119094261-7aac6800-ba19-11eb-9c0e-d5c89b04a1c7.png)
